### PR TITLE
feat: support for nanosecond epoch with 12 byte payload

### DIFF
--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -128,7 +128,7 @@ func printTemplate(id ksuid.KSUID) {
 		String    string
 		Raw       string
 		Time      time.Time
-		Timestamp uint32
+		Timestamp uint64
 		Payload   string
 	}{
 		String:    id.String(),

--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/segmentio/ksuid"
+	"github.com/signoz/ksuid"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/segmentio/ksuid
+module github.com/signoz/ksuid
 
 go 1.12

--- a/ksuid.go
+++ b/ksuid.go
@@ -39,8 +39,8 @@ const (
 
 // KSUIDs are 20 bytes:
 //
-//	00-03 byte: uint32 BE UTC timestamp with custom epoch
-//	04-19 byte: random "payload"
+//	00-07 byte: uint64 BE UTC timestamp with nanosecond epoch
+//	08-19 byte: random "payload"
 type KSUID [byteLength]byte
 
 var (
@@ -237,7 +237,6 @@ func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
 	randMutex.Unlock()
 
 	if err != nil {
-		fmt.Println("error in NewRandomWithTime", err)
 		ksuid = Nil // don't leak random bytes on error
 		return
 	}

--- a/ksuid.go
+++ b/ksuid.go
@@ -15,14 +15,14 @@ import (
 const (
 	// KSUID's epoch starts more recently so that the 32-bit number space gives a
 	// significantly higher useful lifetime of around 136 years from March 2017.
-	// This number (14e8) was picked to be easy to remember.
-	epochStamp int64 = 1400000000
+	// This number (14e8 in seconds) was picked to be easy to remember.
+	epochStamp int64 = 1400000000000000000
 
 	// Timestamp is a uint32
-	timestampLengthInBytes = 4
+	timestampLengthInBytes = 8
 
 	// Payload is 16-bytes
-	payloadLengthInBytes = 16
+	payloadLengthInBytes = 12
 
 	// KSUIDs are 20 bytes when binary encoded
 	byteLength = timestampLengthInBytes + payloadLengthInBytes
@@ -38,8 +38,9 @@ const (
 )
 
 // KSUIDs are 20 bytes:
-//  00-03 byte: uint32 BE UTC timestamp with custom epoch
-//  04-19 byte: random "payload"
+//
+//	00-03 byte: uint32 BE UTC timestamp with custom epoch
+//	04-19 byte: random "payload"
 type KSUID [byteLength]byte
 
 var (
@@ -71,8 +72,8 @@ func (i KSUID) Time() time.Time {
 
 // The timestamp portion of the ID as a bare integer which is uncorrected
 // for KSUID's special epoch.
-func (i KSUID) Timestamp() uint32 {
-	return binary.BigEndian.Uint32(i[:timestampLengthInBytes])
+func (i KSUID) Timestamp() uint64 {
+	return binary.BigEndian.Uint64(i[:timestampLengthInBytes])
 }
 
 // The 16-byte random payload without the timestamp
@@ -201,12 +202,12 @@ func ParseOrNil(s string) KSUID {
 	return ksuid
 }
 
-func timeToCorrectedUTCTimestamp(t time.Time) uint32 {
-	return uint32(t.Unix() - epochStamp)
+func timeToCorrectedUTCTimestamp(t time.Time) uint64 {
+	return uint64(t.UnixNano() - epochStamp)
 }
 
-func correctedUTCTimestampToTime(ts uint32) time.Time {
-	return time.Unix(int64(ts)+epochStamp, 0)
+func correctedUTCTimestampToTime(ts uint64) time.Time {
+	return time.Unix(0, int64(ts)+epochStamp)
 }
 
 // Generates a new KSUID. In the strange case that random bytes
@@ -236,12 +237,13 @@ func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
 	randMutex.Unlock()
 
 	if err != nil {
+		fmt.Println("error in NewRandomWithTime", err)
 		ksuid = Nil // don't leak random bytes on error
 		return
 	}
 
 	ts := timeToCorrectedUTCTimestamp(t)
-	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
+	binary.BigEndian.PutUint64(ksuid[:timestampLengthInBytes], ts)
 	return
 }
 
@@ -254,7 +256,7 @@ func FromParts(t time.Time, payload []byte) (KSUID, error) {
 	var ksuid KSUID
 
 	ts := timeToCorrectedUTCTimestamp(t)
-	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
+	binary.BigEndian.PutUint64(ksuid[:timestampLengthInBytes], ts)
 
 	copy(ksuid[timestampLengthInBytes:], payload)
 
@@ -353,11 +355,11 @@ func quickSort(a []KSUID, lo int, hi int) {
 
 // Next returns the next KSUID after id.
 func (id KSUID) Next() KSUID {
-	zero := makeUint128(0, 0)
+	zero := makeUint96(0, 0)
 
 	t := id.Timestamp()
-	u := uint128Payload(id)
-	v := add128(u, makeUint128(0, 1))
+	u := uint96Payload(id)
+	v := add96(u, makeUint96(0, 1))
 
 	if v == zero { // overflow
 		t++
@@ -368,11 +370,11 @@ func (id KSUID) Next() KSUID {
 
 // Prev returns the previoud KSUID before id.
 func (id KSUID) Prev() KSUID {
-	max := makeUint128(math.MaxUint64, math.MaxUint64)
+	max := makeUint96(math.MaxUint32, math.MaxUint64)
 
 	t := id.Timestamp()
-	u := uint128Payload(id)
-	v := sub128(u, makeUint128(0, 1))
+	u := uint96Payload(id)
+	v := sub96(u, makeUint96(0, 1))
 
 	if v == max { // overflow
 		t--

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -308,8 +308,8 @@ func TestGetTimestamp(t *testing.T) {
 	nowTime := time.Now()
 	x, _ := NewRandomWithTime(nowTime)
 	xTime := int64(x.Timestamp())
-	unix := nowTime.Unix()
-	if xTime != unix - epochStamp {
+	unix := nowTime.UnixNano()
+	if xTime != unix-epochStamp {
 		t.Fatal(xTime, "!=", unix)
 	}
 }

--- a/rand.go
+++ b/rand.go
@@ -49,7 +49,8 @@ type randSourceReader struct {
 
 func (r *randSourceReader) Read(b []byte) (int, error) {
 	// optimized for generating 16 bytes payloads
-	binary.LittleEndian.PutUint64(b[:8], r.source.Uint64())
-	binary.LittleEndian.PutUint64(b[8:], r.source.Uint64())
+	val := r.source.Uint64()
+	binary.LittleEndian.PutUint32(b[:4], uint32(val))       // Use lower 32 bits
+	binary.LittleEndian.PutUint64(b[4:], r.source.Uint64()) // Generate new 64 bits
 	return 16, nil
 }

--- a/set.go
+++ b/set.go
@@ -69,7 +69,7 @@ func AppendCompressed(set []byte, ids ...KSUID) CompressedSet {
 		if !IsSorted(ids) {
 			Sort(ids)
 		}
-		one := makeUint128(0, 1)
+		one := makeUint96(0, 1)
 
 		// The first KSUID is always written to the set, this is the starting
 		// point for all deltas.
@@ -78,7 +78,7 @@ func AppendCompressed(set []byte, ids ...KSUID) CompressedSet {
 
 		timestamp := ids[0].Timestamp()
 		lastKSUID := ids[0]
-		lastValue := uint128Payload(ids[0])
+		lastValue := uint96Payload(ids[0])
 
 		for i := 1; i != len(ids); i++ {
 			id := ids[i]
@@ -88,25 +88,25 @@ func AppendCompressed(set []byte, ids ...KSUID) CompressedSet {
 			}
 
 			t := id.Timestamp()
-			v := uint128Payload(id)
+			v := uint96Payload(id)
 
 			if t != timestamp {
 				d := t - timestamp
-				n := varintLength32(d)
+				n := varintLength64(d)
 
 				set = append(set, timeDelta|byte(n))
-				set = appendVarint32(set, d, n)
+				set = appendVarint64(set, d, n)
 				set = append(set, id[timestampLengthInBytes:]...)
 
 				timestamp = t
 			} else {
-				d := sub128(v, lastValue)
+				d := sub96(v, lastValue)
 
 				if d != one {
-					n := varintLength128(d)
+					n := varintLength96(d)
 
 					set = append(set, payloadDelta|byte(n))
-					set = appendVarint128(set, d, n)
+					set = appendVarint96(set, d, n)
 				} else {
 					l, c := rangeLength(ids[i+1:], t, id, v)
 					m := uint64(l + 1)
@@ -117,7 +117,7 @@ func AppendCompressed(set []byte, ids ...KSUID) CompressedSet {
 
 					i += c
 					id = ids[i]
-					v = uint128Payload(id)
+					v = uint96Payload(id)
 				}
 			}
 
@@ -128,8 +128,8 @@ func AppendCompressed(set []byte, ids ...KSUID) CompressedSet {
 	return CompressedSet(set)
 }
 
-func rangeLength(ids []KSUID, timestamp uint32, lastKSUID KSUID, lastValue uint128) (length int, count int) {
-	one := makeUint128(0, 1)
+func rangeLength(ids []KSUID, timestamp uint64, lastKSUID KSUID, lastValue uint96) (length int, count int) {
+	one := makeUint96(0, 1)
 
 	for i := range ids {
 		id := ids[i]
@@ -143,9 +143,9 @@ func rangeLength(ids []KSUID, timestamp uint32, lastKSUID KSUID, lastValue uint1
 			return
 		}
 
-		v := uint128Payload(id)
+		v := uint96Payload(id)
 
-		if sub128(v, lastValue) != one {
+		if sub96(v, lastValue) != one {
 			count = i
 			return
 		}
@@ -160,6 +160,11 @@ func rangeLength(ids []KSUID, timestamp uint32, lastKSUID KSUID, lastValue uint1
 }
 
 func appendVarint128(b []byte, v uint128, n int) []byte {
+	c := v.bytes()
+	return append(b, c[len(c)-n:]...)
+}
+
+func appendVarint96(b []byte, v uint96, n int) []byte {
 	c := v.bytes()
 	return append(b, c[len(c)-n:]...)
 }
@@ -182,6 +187,12 @@ func varint128(b []byte) uint128 {
 	return makeUint128FromPayload(a[:])
 }
 
+func varint96(b []byte) uint96 {
+	a := [12]byte{}
+	copy(a[12-len(b):], b)
+	return makeUint96FromPayload(a[:])
+}
+
 func varint64(b []byte) uint64 {
 	a := [8]byte{}
 	copy(a[8-len(b):], b)
@@ -195,6 +206,13 @@ func varint32(b []byte) uint32 {
 }
 
 func varintLength128(v uint128) int {
+	if v[1] != 0 {
+		return 8 + varintLength64(v[1])
+	}
+	return varintLength64(v[0])
+}
+
+func varintLength96(v uint96) int {
 	if v[1] != 0 {
 		return 8 + varintLength64(v[1])
 	}
@@ -263,15 +281,15 @@ type CompressedSetIter struct {
 	offset  int
 
 	seqlength uint64
-	timestamp uint32
-	lastValue uint128
+	timestamp uint64
+	lastValue uint96
 }
 
 // Next moves the iterator forward, returning true if there a KSUID was found,
 // or false if the iterator as reached the end of the set it was created from.
 func (it *CompressedSetIter) Next() bool {
 	if it.seqlength != 0 {
-		value := incr128(it.lastValue)
+		value := incr96(it.lastValue)
 		it.KSUID = value.ksuid(it.timestamp)
 		it.seqlength--
 		it.lastValue = value
@@ -298,27 +316,27 @@ func (it *CompressedSetIter) Next() bool {
 
 		it.offset = off1
 		it.timestamp = it.KSUID.Timestamp()
-		it.lastValue = uint128Payload(it.KSUID)
+		it.lastValue = uint96Payload(it.KSUID)
 
 	case timeDelta:
 		off0 := it.offset
 		off1 := off0 + cnt
 		off2 := off1 + payloadLengthInBytes
 
-		it.timestamp += varint32(it.content[off0:off1])
+		it.timestamp += varint64(it.content[off0:off1])
 
-		binary.BigEndian.PutUint32(it.KSUID[:timestampLengthInBytes], it.timestamp)
+		binary.BigEndian.PutUint64(it.KSUID[:8], it.timestamp)
 		copy(it.KSUID[timestampLengthInBytes:], it.content[off1:off2])
 
 		it.offset = off2
-		it.lastValue = uint128Payload(it.KSUID)
+		it.lastValue = uint96Payload(it.KSUID)
 
 	case payloadDelta:
 		off0 := it.offset
 		off1 := off0 + cnt
 
-		delta := varint128(it.content[off0:off1])
-		value := add128(it.lastValue, delta)
+		delta := varint96(it.content[off0:off1])
+		value := add96(it.lastValue, delta)
 
 		it.KSUID = value.ksuid(it.timestamp)
 		it.offset = off1
@@ -328,7 +346,7 @@ func (it *CompressedSetIter) Next() bool {
 		off0 := it.offset
 		off1 := off0 + cnt
 
-		value := incr128(it.lastValue)
+		value := incr96(it.lastValue)
 		it.KSUID = value.ksuid(it.timestamp)
 		it.seqlength = varint64(it.content[off0:off1])
 		it.offset = off1

--- a/set.go
+++ b/set.go
@@ -213,10 +213,13 @@ func varintLength128(v uint128) int {
 }
 
 func varintLength96(v uint96) int {
-	if v[1] != 0 {
-		return 8 + varintLength64(v[1])
+	if v[2] != 0 {
+		return 8 + varintLength32(v[2])
 	}
-	return varintLength64(v[0])
+	if v[1] != 0 {
+		return 4 + varintLength32(v[1])
+	}
+	return varintLength32(v[0])
 }
 
 func varintLength64(v uint64) int {

--- a/uint96.go
+++ b/uint96.go
@@ -7,6 +7,11 @@ import (
 )
 
 // uint96 represents an unsigned 96 bits little endian integer.
+
+// So there are two different endian considerations here:
+// The internal array structure is little-endian (lowest bits in lowest index)
+// The external byte serialization is big-endian (highest bits in lowest byte address)
+
 type uint96 [3]uint32 // [0] holds low 32 bits, [1] holds middle 32 bits, [2] holds high 32 bits
 
 func uint96Payload(ksuid KSUID) uint96 {
@@ -39,6 +44,7 @@ func (v uint96) ksuid(timestamp uint64) (out KSUID) {
 	return
 }
 
+// The external byte serialization is big-endian (highest bits in lowest byte address)
 func (v uint96) bytes() (out [12]byte) {
 	binary.BigEndian.PutUint32(out[:4], v[2])
 	binary.BigEndian.PutUint32(out[4:8], v[1])

--- a/uint96.go
+++ b/uint96.go
@@ -1,0 +1,81 @@
+package ksuid
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+)
+
+// uint96 represents an unsigned 96 bits little endian integer.
+type uint96 [2]uint64 // [0] holds low 64 bits, [1] holds high 32 bits
+
+func uint96Payload(ksuid KSUID) uint96 {
+	return makeUint96FromPayload(ksuid[timestampLengthInBytes:])
+}
+
+func makeUint96(high uint32, low uint64) uint96 {
+	return uint96{low, uint64(high)}
+}
+
+func makeUint96FromPayload(payload []byte) uint96 {
+	return uint96{
+		binary.BigEndian.Uint64(payload[4:]),         // low (8 bytes)
+		uint64(binary.BigEndian.Uint32(payload[:4])), // high (4 bytes)
+	}
+}
+
+func (v uint96) ksuid(timestamp uint64) (out KSUID) {
+	binary.BigEndian.PutUint64(out[:8], timestamp)      // time (8 bytes)
+	binary.BigEndian.PutUint32(out[8:12], uint32(v[1])) // high (4 bytes)
+	binary.BigEndian.PutUint64(out[12:], v[0])          // low (8 bytes)
+	return
+}
+
+func (v uint96) bytes() (out [12]byte) {
+	binary.BigEndian.PutUint32(out[:4], uint32(v[1]))
+	binary.BigEndian.PutUint64(out[4:], v[0])
+	return
+}
+
+func (v uint96) String() string {
+	return fmt.Sprintf("0x%08X%016X", uint32(v[1]), v[0])
+}
+
+func cmp96(x, y uint96) int {
+	if x[1] < y[1] {
+		return -1
+	}
+	if x[1] > y[1] {
+		return 1
+	}
+	if x[0] < y[0] {
+		return -1
+	}
+	if x[0] > y[0] {
+		return 1
+	}
+	return 0
+}
+
+func add96(x, y uint96) (z uint96) {
+	var c uint64
+	z[0], c = bits.Add64(x[0], y[0], 0)
+	z[1], _ = bits.Add64(x[1], y[1], c)
+	z[1] &= 0xFFFFFFFF // Mask to 32 bits
+	return
+}
+
+func sub96(x, y uint96) (z uint96) {
+	var b uint64
+	z[0], b = bits.Sub64(x[0], y[0], 0)
+	z[1], _ = bits.Sub64(x[1], y[1], b)
+	z[1] &= 0xFFFFFFFF // Mask to 32 bits
+	return
+}
+
+func incr96(x uint96) (z uint96) {
+	var c uint64
+	z[0], c = bits.Add64(x[0], 1, 0)
+	z[1] = (x[1] + c) & 0xFFFFFFFF // Add carry and mask to 32 bits
+	return
+}

--- a/uint96.go
+++ b/uint96.go
@@ -7,41 +7,56 @@ import (
 )
 
 // uint96 represents an unsigned 96 bits little endian integer.
-type uint96 [2]uint64 // [0] holds low 64 bits, [1] holds high 32 bits
+type uint96 [3]uint32 // [0] holds low 32 bits, [1] holds middle 32 bits, [2] holds high 32 bits
 
 func uint96Payload(ksuid KSUID) uint96 {
 	return makeUint96FromPayload(ksuid[timestampLengthInBytes:])
 }
 
+// uint32(low): Takes the lowest 32 bits of the low uint64
+// uint32(low >> 32): Shifts the low value right by 32 bits and takes the result, giving us the middle 32 bits
 func makeUint96(high uint32, low uint64) uint96 {
-	return uint96{low, uint64(high)}
+	return uint96{
+		uint32(low),       // lowest 32 bits
+		uint32(low >> 32), // middle 32 bits
+		high,              // highest 32 bits
+	}
 }
 
 func makeUint96FromPayload(payload []byte) uint96 {
 	return uint96{
-		binary.BigEndian.Uint64(payload[4:]),         // low (8 bytes)
-		uint64(binary.BigEndian.Uint32(payload[:4])), // high (4 bytes)
+		binary.BigEndian.Uint32(payload[8:]),  // low (4 bytes)
+		binary.BigEndian.Uint32(payload[4:8]), // middle (4 bytes)
+		binary.BigEndian.Uint32(payload[:4]),  // high (4 bytes)
 	}
 }
 
 func (v uint96) ksuid(timestamp uint64) (out KSUID) {
-	binary.BigEndian.PutUint64(out[:8], timestamp)      // time (8 bytes)
-	binary.BigEndian.PutUint32(out[8:12], uint32(v[1])) // high (4 bytes)
-	binary.BigEndian.PutUint64(out[12:], v[0])          // low (8 bytes)
+	binary.BigEndian.PutUint64(out[:8], timestamp) // time (8 bytes)
+	binary.BigEndian.PutUint32(out[8:12], v[2])    // high (4 bytes)
+	binary.BigEndian.PutUint32(out[12:16], v[1])   // middle (4 bytes)
+	binary.BigEndian.PutUint32(out[16:], v[0])     // low (4 bytes)
 	return
 }
 
 func (v uint96) bytes() (out [12]byte) {
-	binary.BigEndian.PutUint32(out[:4], uint32(v[1]))
-	binary.BigEndian.PutUint64(out[4:], v[0])
+	binary.BigEndian.PutUint32(out[:4], v[2])
+	binary.BigEndian.PutUint32(out[4:8], v[1])
+	binary.BigEndian.PutUint32(out[8:], v[0])
 	return
 }
 
 func (v uint96) String() string {
-	return fmt.Sprintf("0x%08X%016X", uint32(v[1]), v[0])
+	return fmt.Sprintf("0x%08X%08X%08X", v[2], v[1], v[0])
 }
 
 func cmp96(x, y uint96) int {
+	if x[2] < y[2] {
+		return -1
+	}
+	if x[2] > y[2] {
+		return 1
+	}
 	if x[1] < y[1] {
 		return -1
 	}
@@ -58,24 +73,25 @@ func cmp96(x, y uint96) int {
 }
 
 func add96(x, y uint96) (z uint96) {
-	var c uint64
-	z[0], c = bits.Add64(x[0], y[0], 0)
-	z[1], _ = bits.Add64(x[1], y[1], c)
-	z[1] &= 0xFFFFFFFF // Mask to 32 bits
+	var c uint32
+	z[0], c = bits.Add32(x[0], y[0], 0)
+	z[1], c = bits.Add32(x[1], y[1], c)
+	z[2], _ = bits.Add32(x[2], y[2], c)
 	return
 }
 
 func sub96(x, y uint96) (z uint96) {
-	var b uint64
-	z[0], b = bits.Sub64(x[0], y[0], 0)
-	z[1], _ = bits.Sub64(x[1], y[1], b)
-	z[1] &= 0xFFFFFFFF // Mask to 32 bits
+	var b uint32
+	z[0], b = bits.Sub32(x[0], y[0], 0)
+	z[1], b = bits.Sub32(x[1], y[1], b)
+	z[2], _ = bits.Sub32(x[2], y[2], b)
 	return
 }
 
 func incr96(x uint96) (z uint96) {
-	var c uint64
-	z[0], c = bits.Add64(x[0], 1, 0)
-	z[1] = (x[1] + c) & 0xFFFFFFFF // Add carry and mask to 32 bits
+	var c uint32
+	z[0], c = bits.Add32(x[0], 1, 0)
+	z[1], c = bits.Add32(x[1], c, 0)
+	z[2], _ = bits.Add32(x[2], c, 0)
 	return
 }

--- a/uint96_test.go
+++ b/uint96_test.go
@@ -1,0 +1,212 @@
+package ksuid
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCmp96(t *testing.T) {
+	tests := []struct {
+		x uint96
+		y uint96
+		k int
+	}{
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 0),
+			k: 0,
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(0, 0),
+			k: +1,
+		},
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 1),
+			k: -1,
+		},
+		{
+			x: makeUint96(1, 0),
+			y: makeUint96(0, 1),
+			k: +1,
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(1, 0),
+			k: -1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("cmp96(%s,%s)", test.x, test.y), func(t *testing.T) {
+			if k := cmp96(test.x, test.y); k != test.k {
+				t.Error(k, "!=", test.k)
+			}
+		})
+	}
+}
+
+func TestAdd96(t *testing.T) {
+	tests := []struct {
+		x uint96
+		y uint96
+		z uint96
+	}{
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 0),
+			z: makeUint96(0, 0),
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(0, 0),
+			z: makeUint96(0, 1),
+		},
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 1),
+			z: makeUint96(0, 1),
+		},
+		{
+			x: makeUint96(1, 0),
+			y: makeUint96(0, 1),
+			z: makeUint96(1, 1),
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(1, 0),
+			z: makeUint96(1, 1),
+		},
+		{
+			x: makeUint96(0, 0xFFFFFFFFFFFFFFFF),
+			y: makeUint96(0, 1),
+			z: makeUint96(1, 0),
+		},
+		// Test 32-bit overflow masking
+		{
+			x: makeUint96(0xFFFFFFFF, 0),
+			y: makeUint96(1, 0),
+			z: makeUint96(0, 0), // Should wrap around due to 32-bit mask
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("add96(%s,%s)", test.x, test.y), func(t *testing.T) {
+			if z := add96(test.x, test.y); z != test.z {
+				t.Error(z, "!=", test.z)
+			}
+		})
+	}
+}
+
+func TestSub96(t *testing.T) {
+	tests := []struct {
+		x uint96
+		y uint96
+		z uint96
+	}{
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 0),
+			z: makeUint96(0, 0),
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(0, 0),
+			z: makeUint96(0, 1),
+		},
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(0, 1),
+			z: makeUint96(0xFFFFFFFF, 0xFFFFFFFFFFFFFFFF),
+		},
+		{
+			x: makeUint96(1, 0),
+			y: makeUint96(0, 1),
+			z: makeUint96(0, 0xFFFFFFFFFFFFFFFF),
+		},
+		{
+			x: makeUint96(0, 1),
+			y: makeUint96(1, 0),
+			z: makeUint96(0xFFFFFFFF, 1),
+		},
+		// Test 32-bit underflow masking
+		{
+			x: makeUint96(0, 0),
+			y: makeUint96(1, 0),
+			z: makeUint96(0xFFFFFFFF, 0),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("sub96(%s,%s)", test.x, test.y), func(t *testing.T) {
+			if z := sub96(test.x, test.y); z != test.z {
+				t.Error(z, "!=", test.z)
+			}
+		})
+	}
+}
+
+func TestIncr96(t *testing.T) {
+	tests := []struct {
+		x uint96
+		z uint96
+	}{
+		{
+			x: makeUint96(0, 0),
+			z: makeUint96(0, 1),
+		},
+		{
+			x: makeUint96(0, 0xFFFFFFFFFFFFFFFF),
+			z: makeUint96(1, 0),
+		},
+		{
+			x: makeUint96(0xFFFFFFFF, 0xFFFFFFFFFFFFFFFF),
+			z: makeUint96(0, 0), // Should wrap around due to 32-bit mask
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("incr96(%s)", test.x), func(t *testing.T) {
+			if z := incr96(test.x); z != test.z {
+				t.Error(z, "!=", test.z)
+			}
+		})
+	}
+}
+
+func BenchmarkCmp96(b *testing.B) {
+	x := makeUint96(0, 0)
+	y := makeUint96(0, 0)
+
+	for i := 0; i != b.N; i++ {
+		cmp96(x, y)
+	}
+}
+
+func BenchmarkAdd96(b *testing.B) {
+	x := makeUint96(0, 0)
+	y := makeUint96(0, 0)
+
+	for i := 0; i != b.N; i++ {
+		add96(x, y)
+	}
+}
+
+func BenchmarkSub96(b *testing.B) {
+	x := makeUint96(0, 0)
+	y := makeUint96(0, 0)
+
+	for i := 0; i != b.N; i++ {
+		sub96(x, y)
+	}
+}
+
+func BenchmarkIncr96(b *testing.B) {
+	x := makeUint96(0, 0)
+
+	for i := 0; i != b.N; i++ {
+		incr96(x)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/SigNoz/signoz/issues/6365

Original 
* timestamp in seconds - 4 bytes
* random payload of 16 bytes

Updated
* timestamp in nanoseconds - 8 bytes
* random payload of 12 bytes

Therefore the binary representation is 20 bytes and text representation is 27 bytes which remains the same.


**Original** Ksuid has a random payload of 16 bytes, giving approximately 2^128 possible random combinations per second. 

**Updated** ksuid has a random payload of 12 bytes, giving approximately 2^96  possible random combinations per nanosecond

How does it affect us
Previously
* If the user gave a timestamp in seconds/nanosecond we had 2^128 random possible uinque id's, also anything after the seconds precision is not respected so order broke.

Now
* If a user gives a timestamp in seconds/ns we have 2^96 possible uinique id's and the precision till ns will be respected thus ordering will be preserved as long as the user gives more precise timestamp.


Also 2^96 is still an huge space.

I have created a benchmark which tries to generate id's for the same nanosecond timestamp, I ran it for 1 min which generated 100 million id's without any collision.

```
➜  ksuid git:(feat/epoch_nano_27_byte) ✗ go test -bench BenchmarkCollisionProbability -benchtime=60s

0evaQdfvbvDySvxz8w7AfrikYY0 0evaQdfvcM1z3edokbpdKZo1Lsj
goos: darwin
goarch: arm64
pkg: github.com/signoz/ksuid
cpu: Apple M3 Pro
BenchmarkCollisionProbability-11        100000000              713.1 ns/op               0 collisions
PASS
ok      github.com/signoz/ksuid 72.934s
```
------

## Usage

Prev
```
➜  ksuid git:(master) ✗ go run cmd/ksuid/main.go -n 2                                  
2phFc2dzLsM9Zt1petCin8gfSSA
2phFc37W7uwadId97wQfkxu2yIu

➜  ksuid git:(master) ✗ go run cmd/ksuid/main.go -f inspect 2phFc2dzLsM9Zt1petCin8gfSSA                           

REPRESENTATION:

  String: 2phFc2dzLsM9Zt1petCin8gfSSA
     Raw: 13DC636BDD91C3F9473C1308C5B96E06912CF2DA

COMPONENTS:

       Time: 2024-12-03 12:51:15 +0530 IST
  Timestamp: 333210475
    Payload: DD91C3F9473C1308C5B96E06912CF2DA

➜  ksuid git:(master) ✗ go run cmd/ksuid/main.go -f inspect 2phFc37W7uwadId97wQfkxu2yIu                           

REPRESENTATION:

  String: 2phFc37W7uwadId97wQfkxu2yIu
     Raw: 13DC636BED37D384BC3E10A60C76EB2DD391D894

COMPONENTS:

       Time: 2024-12-03 12:51:15 +0530 IST
  Timestamp: 333210475
    Payload: ED37D384BC3E10A60C76EB2DD391D894

```


New

```
➜  ksuid git:(feat/epoch_nano_27_byte) ✗ go run cmd/ksuid/main.go -n 2                                  
0euHOuHoY2okD1KHtAImPc0jS7W
0euHOuHoZm2rD2OLvC5342XLWp0


➜  ksuid git:(feat/epoch_nano_27_byte) ✗ go run cmd/ksuid/main.go -f inspect 0euHOuHoY2okD1KHtAImPc0jS7W                           

REPRESENTATION:

  String: 0euHOuHoY2okD1KHtAImPc0jS7W
     Raw: 049FCCE76CC96E30A366D0885137AA3FA5D5AF5A

COMPONENTS:

       Time: 2024-12-03 12:46:31.783358 +0530 IST
  Timestamp: 333210191783358000
    Payload: A366D0885137AA3FA5D5AF5A

➜  ksuid git:(feat/epoch_nano_27_byte) ✗ go run cmd/ksuid/main.go -f inspect 0euHOuHoZm2rD2OLvC5342XLWp0                           

REPRESENTATION:

  String: 0euHOuHoZm2rD2OLvC5342XLWp0
     Raw: 049FCCE76CC97DD0E056AC26E414F1804553A582

COMPONENTS:

       Time: 2024-12-03 12:46:31.783362 +0530 IST
  Timestamp: 333210191783362000
    Payload: E056AC26E414F1804553A582
```